### PR TITLE
Wsparcie dla ActiveModel

### DIFF
--- a/lib/polish/locale/activerecord.yml
+++ b/lib/polish/locale/activerecord.yml
@@ -1,5 +1,5 @@
 pl:
-  activerecord:
+  activerecord: &activemodel
     errors:
       template:
         header:
@@ -33,3 +33,6 @@ pl:
         less_than_or_equal_to: "musi być mniejsze lub równe %{count}"
         odd: "musi być nieparzyste"
         even: "musi być parzyste"
+        
+  activemodel:
+    <<: *active_model 

--- a/lib/polish/locale/activerecord.yml
+++ b/lib/polish/locale/activerecord.yml
@@ -1,5 +1,5 @@
 pl:
-  activerecord: &activemodel
+  activerecord: &active_model
     errors:
       template:
         header:


### PR DESCRIPTION
Dodałem wsparcie dla ActiveModel. ActiveModel dziedziczy po prostu translacje po ActiveRecord.
