### PR TITLE
Added support for no-padded day of month (%-d)

### DIFF
--- a/lib/polish/locale/datetime.rb
+++ b/lib/polish/locale/datetime.rb
@@ -4,7 +4,7 @@
   :'pl' => {
     :date => {
       :month_names => lambda { |date_or_time, opts|
-        if opts[:format] =~ /(%d|%e)(.*)(%B)/
+        if opts[:format] =~ /(%d|%-d|%e)(.*)(%B)/
           [nil, 'stycznia', 'lutego', 'marca', 'kwietnia', 'maja', 'czerwca', 
            'lipca', 'sierpnia', 'września', 'października', 'listopada', 
            'grudnia']

--- a/polish.gemspec
+++ b/polish.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency "rake"
   s.add_dependency "bundler"
 
-  s.add_development_dependency "rspec", ">= 2.8.0"
+  s.add_development_dependency "rspec", ">= 2.8.0", "< 3.0"
 end
 

--- a/spec/i18n/locale/datetime_spec.rb
+++ b/spec/i18n/locale/datetime_spec.rb
@@ -43,8 +43,10 @@ describe I18n, "Polish Date/Time localization" do
   describe "with month names" do
     it "should use month names" do
       l(@date, :format => "%d %B").should == "01 grudnia"
+      l(@date, :format => "%-d %B").should == "1 grudnia"
       l(@date, :format => "%e %B %Y").should == " 1 grudnia 1985"
       l(@date, :format => "<b>%d</b> %B").should == "<b>01</b> grudnia"
+      l(@date, :format => "<b>%-d</b> %B").should == "<b>1</b> grudnia"
       l(@date, :format => "<strong>%e</strong> %B %Y").should ==
                                             "<strong> 1</strong> grudnia 1985"
       l(@date, :format => "A było to dnia %ego miesiąca %B %Y").should ==


### PR DESCRIPTION
Up to now month names were inflected only when used after %d (0-padded) or %e (blank-padded). This adds no-padded version - %-d to the list.